### PR TITLE
Feat/log loss for pretrain

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "FSRS-Optimizer"
-version = "4.14.3"
+version = "4.15.0"
 readme = "README.md"
 dependencies = [
     "matplotlib>=3.7.0",

--- a/src/fsrs_optimizer/fsrs_optimizer.py
+++ b/src/fsrs_optimizer/fsrs_optimizer.py
@@ -859,7 +859,7 @@ class Optimizer:
                     * count
                     / total_count
                 )
-                l1 = np.abs(stability - init_s0) / total_count * 0.1
+                l1 = np.abs(stability - init_s0) / total_count / 16
                 return logloss + l1
 
             res = minimize(

--- a/src/fsrs_optimizer/fsrs_optimizer.py
+++ b/src/fsrs_optimizer/fsrs_optimizer.py
@@ -854,9 +854,13 @@ class Optimizer:
 
             def loss(stability):
                 y_pred = power_forgetting_curve(delta_t, stability)
-                rmse = np.sqrt(np.sum((recall - y_pred) ** 2 * count) / total_count)
-                l1 = np.abs(stability - init_s0) / np.sqrt(s0_size) / total_count
-                return rmse + l1
+                logloss = sum(
+                    -(recall * np.log(y_pred) + (1 - recall) * np.log(1 - y_pred))
+                    * count
+                    / total_count
+                )
+                l1 = np.abs(stability - init_s0) / total_count * 0.1
+                return logloss + l1
 
             res = minimize(
                 loss,


### PR DESCRIPTION
Weighted by size:

```
Model: FSRSv4
Total number of users: 71
Total number of reviews: 4632965
metric: LogLoss
FSRSv4 mean: 0.3874
metric: RMSE
FSRSv4 mean: 0.3347
metric: RMSE(bins)
FSRSv4 mean: 0.0459
```

Weighted by ln(size):

```
Model: FSRSv4
Total number of users: 71
Total number of reviews: 4632965
metric: LogLoss
FSRSv4 mean: 0.3820
metric: RMSE
FSRSv4 mean: 0.3311
metric: RMSE(bins)
FSRSv4 mean: 0.0547
```