### PR TITLE
Remove stratified group k fold

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "FSRS-Optimizer"
-version = "4.27.2"
+version = "4.27.3"
 readme = "README.md"
 dependencies = [
     "matplotlib>=3.7.0",


### PR DESCRIPTION
According to the recent result of benchmark, splitting dataset into several subsets, optimizing FSRS on them and averaging the parameters don't perform better than non-splitting. So I removed it in this PR. It also makes the optimization faster.

```
Model: FSRS-4.5-split
Total number of users: 19993
Total number of reviews: 728883020
Weighted average by reviews:
FSRS-4.5 LogLoss (mean±std): 0.3293±0.1538
FSRS-4.5 LogLoss: 0.33±0.006
FSRS-4.5 RMSE(bins) (mean±std): 0.0569±0.0358
FSRS-4.5 RMSE(bins): 0.057±0.0011

Weighted average by log(reviews):
FSRS-4.5 LogLoss (mean±std): 0.3544±0.1723
FSRS-4.5 LogLoss: 0.354±0.0031
FSRS-4.5 RMSE(bins) (mean±std): 0.0783±0.0506
FSRS-4.5 RMSE(bins): 0.078±0.0009

Weighted average by users:
FSRS-4.5 LogLoss (mean±std): 0.3583±0.1749
FSRS-4.5 LogLoss: 0.358±0.0031
FSRS-4.5 RMSE(bins) (mean±std): 0.0817±0.0527
FSRS-4.5 RMSE(bins): 0.082±0.0010

weights: [0.6646, 1.7213, 5.18, 12.4195, 5.1978, 1.2412, 0.8733, 0.0467, 1.617, 0.1342, 1.0166, 2.0894, 0.0871, 0.3185, 1.5606, 0.219, 2.8747]

Model: FSRS-4.5-non-split
Total number of users: 19993
Total number of reviews: 728883020
Weighted average by reviews:
FSRS-4.5-old LogLoss (mean±std): 0.3293±0.1538
FSRS-4.5-old LogLoss: 0.33±0.006
FSRS-4.5-old RMSE(bins) (mean±std): 0.0567±0.0359
FSRS-4.5-old RMSE(bins): 0.057±0.0011

Weighted average by log(reviews):
FSRS-4.5-old LogLoss (mean±std): 0.3544±0.1726
FSRS-4.5-old LogLoss: 0.354±0.0031
FSRS-4.5-old RMSE(bins) (mean±std): 0.0780±0.0507
FSRS-4.5-old RMSE(bins): 0.078±0.0009

Weighted average by users:
FSRS-4.5-old LogLoss (mean±std): 0.3583±0.1752
FSRS-4.5-old LogLoss: 0.358±0.0032
FSRS-4.5-old RMSE(bins) (mean±std): 0.0815±0.0528
FSRS-4.5-old RMSE(bins): 0.081±0.0010

weights: [0.6646, 1.7213, 5.18, 12.4195, 5.201, 1.2504, 0.8733, 0.041, 1.6164, 0.1336, 1.0205, 2.0841, 0.0865, 0.3184, 1.5798, 0.219, 2.8852]
```