### PR TITLE
Fine-tune the sample size for CMRR.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "FSRS-Optimizer"
-version = "5.0.7"
+version = "5.0.8"
 readme = "README.md"
 dependencies = [
     "matplotlib>=3.7.0",

--- a/src/fsrs_optimizer/fsrs_simulator.py
+++ b/src/fsrs_optimizer/fsrs_simulator.py
@@ -530,7 +530,7 @@ def workload_graph(default_params, sampling_size=30):
     elif max_w >= 3 * min_w:
         lim = 3 * min_w
     else:
-        lim = max(max_w, 2.7 * min_w)
+        lim = 1.1 * max_w
 
     ax.set_ylim(0, lim)
     ax.set_ylabel("Workload (minutes of study per day)", fontsize=20)

--- a/src/fsrs_optimizer/fsrs_simulator.py
+++ b/src/fsrs_optimizer/fsrs_simulator.py
@@ -263,7 +263,7 @@ def sample(
 ):
     memorization = []
 
-    def _sample_size(days_to_simulate):
+    def best_sample_size(days_to_simulate):
         if days_to_simulate <= 30:
             return 36
         elif days_to_simulate >= 365:

--- a/src/fsrs_optimizer/fsrs_simulator.py
+++ b/src/fsrs_optimizer/fsrs_simulator.py
@@ -521,14 +521,14 @@ def workload_graph(default_params, sampling_size=30):
     ax.xaxis.set_tick_params(labelsize=14)
     ax.set_xlim(0.7, 0.99)
 
-    if max_w >= 4.5 * min_w:
-        lim = 4.5 * min_w
-    elif max_w >= 4 * min_w:
-        lim = 4 * min_w
-    elif max_w >= 3.5 * min_w:
+    if max_w >= 3.5 * min_w:
         lim = 3.5 * min_w
     elif max_w >= 3 * min_w:
         lim = 3 * min_w
+    elif max_w >= 2.5 * min_w:
+        lim = 2.5 * min_w
+    elif max_w >= 2 * min_w:
+        lim = 2 * min_w
     else:
         lim = 1.1 * max_w
 

--- a/src/fsrs_optimizer/fsrs_simulator.py
+++ b/src/fsrs_optimizer/fsrs_simulator.py
@@ -523,10 +523,14 @@ def workload_graph(default_params, sampling_size=30):
 
     if max_w >= 4.5 * min_w:
         lim = 4.5 * min_w
+    elif max_w >= 4 * min_w:
+        lim = 4 * min_w
     elif max_w >= 3.5 * min_w:
         lim = 3.5 * min_w
+    elif max_w >= 3 * min_w:
+        lim = 3 * min_w
     else:
-        lim = 1.1 * max_w
+        lim = max(max_w, 2.7 * min_w)
 
     ax.set_ylim(0, lim)
     ax.set_ylabel("Workload (minutes of study per day)", fontsize=20)

--- a/src/fsrs_optimizer/fsrs_simulator.py
+++ b/src/fsrs_optimizer/fsrs_simulator.py
@@ -429,6 +429,7 @@ def workload_graph(default_params, sampling_size=30):
         default_params["deck_size"] / default_params["learn_span"]
     )
     default_params["review_limit_perday"] = math.inf
+    default_params["loss_aversion"] = 1
     workload = [sample(r=r, workload_only=True, **default_params) for r in R]
 
     # this is for testing

--- a/src/fsrs_optimizer/fsrs_simulator.py
+++ b/src/fsrs_optimizer/fsrs_simulator.py
@@ -270,7 +270,7 @@ def sample(
         elif days_to_simulate >= 365:
             return 4
         else:
-            factor = 0.00000358 * np.power(days_to_simulate, 2) + 0.00113 * days_to_simulate + 0.0733
+            factor = 8.54864e-07 * np.power(days_to_simulate, 2) + 2.57563e-03 * days_to_simulate + 1.38928e-02
             default_sample_size = 4
             return int(default_sample_size/factor)
     

--- a/src/fsrs_optimizer/fsrs_simulator.py
+++ b/src/fsrs_optimizer/fsrs_simulator.py
@@ -264,13 +264,14 @@ def sample(
 ):
     results = []
 
-    def best_sample_size(days_to_simulate):
+    def _sample_size(days_to_simulate):
         if days_to_simulate <= 30:
             return 36
         elif days_to_simulate >= 365:
             return 4
         else:
-            factor = 8.54864e-07 * np.power(days_to_simulate, 2) + 2.57563e-03 * days_to_simulate + 1.38928e-02
+            a1, a2, a3 = 8.20e-07, 2.41e-03, 1.30e-02
+            factor = a1 * np.power(days_to_simulate, 2) + a2 * days_to_simulate + a3
             default_sample_size = 4
             return int(default_sample_size/factor)
     

--- a/src/fsrs_optimizer/fsrs_simulator.py
+++ b/src/fsrs_optimizer/fsrs_simulator.py
@@ -266,7 +266,7 @@ def sample(
 
     def best_sample_size(days_to_simulate):
         if days_to_simulate <= 30:
-            return 36
+            return 45
         elif days_to_simulate >= 365:
             return 4
         else:

--- a/src/fsrs_optimizer/fsrs_simulator.py
+++ b/src/fsrs_optimizer/fsrs_simulator.py
@@ -545,7 +545,7 @@ def workload_graph(default_params, sampling_size=30):
         color="black",
         fontsize=12,
     )
-    if max_w >= 1.8 * min_w:
+    if lim >= 1.8 * min_w:
         ax.axhline(y=1.5 * min_w, color="black", alpha=0.75, ls="--")
         ax.text(
             0.701,
@@ -556,7 +556,7 @@ def workload_graph(default_params, sampling_size=30):
             color="black",
             fontsize=12,
         )
-    if max_w >= 2.3 * min_w:
+    if lim >= 2.3 * min_w:
         ax.axhline(y=2 * min_w, color="black", alpha=0.75, ls="--")
         ax.text(
             0.701,
@@ -567,7 +567,7 @@ def workload_graph(default_params, sampling_size=30):
             color="black",
             fontsize=12,
         )
-    if max_w >= 2.8 * min_w:
+    if lim >= 2.8 * min_w:
         ax.axhline(y=2.5 * min_w, color="black", alpha=0.75, ls="--")
         ax.text(
             0.701,
@@ -578,7 +578,7 @@ def workload_graph(default_params, sampling_size=30):
             color="black",
             fontsize=12,
         )
-    if max_w >= 3.3 * min_w:
+    if lim >= 3.3 * min_w:
         ax.axhline(y=3 * min_w, color="black", alpha=0.75, ls="--")
         ax.text(
             0.701,

--- a/src/fsrs_optimizer/fsrs_simulator.py
+++ b/src/fsrs_optimizer/fsrs_simulator.py
@@ -539,7 +539,7 @@ def workload_graph(default_params, sampling_size=30):
     ax.text(
         0.701,
         min_w,
-        "min. workload",
+        "minimum workload",
         ha="left",
         va="bottom",
         color="black",

--- a/src/fsrs_optimizer/fsrs_simulator.py
+++ b/src/fsrs_optimizer/fsrs_simulator.py
@@ -263,13 +263,13 @@ def sample(
 ):
     memorization = []
 
-    def best_sample_size(days_to_simulate):
+    def _sample_size(days_to_simulate):
         if days_to_simulate <= 30:
             return 36
         elif days_to_simulate >= 365:
             return 4
         else:
-            factor = 0.00000358 * np.power(days_to_simulate, 2) + 0.00113 * days_to_simulate +0.0733
+            factor = 0.00000358 * np.power(days_to_simulate, 2) + 0.00113 * days_to_simulate + 0.0733
             default_sample_size = 4
             return int(default_sample_size/factor)
     

--- a/src/fsrs_optimizer/fsrs_simulator.py
+++ b/src/fsrs_optimizer/fsrs_simulator.py
@@ -264,7 +264,7 @@ def sample(
 ):
     results = []
 
-    def _sample_size(days_to_simulate):
+    def best_sample_size(days_to_simulate):
         if days_to_simulate <= 30:
             return 36
         elif days_to_simulate >= 365:

--- a/src/fsrs_optimizer/fsrs_simulator.py
+++ b/src/fsrs_optimizer/fsrs_simulator.py
@@ -262,12 +262,18 @@ def sample(
     loss_aversion=2.5,
 ):
     memorization = []
-    if learn_span < 100:
-        SAMPLE_SIZE = 16
-    elif learn_span < 365:
-        SAMPLE_SIZE = 8
-    else:
-        SAMPLE_SIZE = 4
+
+    def best_sample_size(days_to_simulate):
+        if days_to_simulate <= 30:
+            return 36
+        elif days_to_simulate >= 365:
+            return 4
+        else:
+            factor = 0.00000358 * np.power(days_to_simulate, 2) + 0.00113 * days_to_simulate +0.0733
+            default_sample_size = 4
+            return int(default_sample_size/factor)
+    
+    SAMPLE_SIZE = best_sample_size(learn_span)
 
     for i in range(SAMPLE_SIZE):
         _, _, _, memorized_cnt_per_day, cost_per_day = simulate(


### PR DESCRIPTION
So here's the idea: the amount of time it takes to run CMRR for small values of days_to_simulate is very small. Which means that we can increase the sample size without having to worry about CMRR taking too long to annoy the user.

Instead of writing a whole bunch of else-if statements, I made a function that calculates the "best" sample size. Specifically, it calculates what sample size would make CMRR run roughly as long as it would with sample_size=4 and days_to_simulate=365. 

sample_size=4 and days_to_simulate=365 is used as the default, and then if days_to_simulate is lower, sample size is increased to make the total run time approximately constant for days_to_simulate <=365.

You can run something like:
```
for i in range(1, 366):
    print(i, best_sample_size(i))
```
to see what sample size values it outputs for each value of days_to_simulate.

Don't forget to add this to FSRS-rs and merge it into Anki.