### PR TITLE
fix scipy dependency conflict

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "FSRS-Optimizer"
-version = "5.0.8"
+version = "5.0.9"
 readme = "README.md"
 dependencies = [
     "matplotlib>=3.7.0",
@@ -15,6 +15,7 @@ dependencies = [
     "torch>=1.13.1",
     "tqdm>=4.64.1",
     "statsmodels>=0.13.5",
+    "scipy<1.14.1"
 ]
 requires-python = ">=3.9"
 


### PR DESCRIPTION
There's currently a [dependency conflict](https://stackoverflow.com/questions/78900274/scipy-1-14-1-breaks-statsmodels-0-14-2) between the latest versions of numpy and scipy (2.1.1 and 1.4.1) and as a result, this package doesn't work for me.

To fix this, I specified an upper version for scipy (<1.4.1) and that fixed it.

I also bumped the version 5.0.8 -> 5.0.9.

Let me know if there are any issues/questions 👍