### PR TITLE
add github action to automate tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+name: Test Python
+
+on: [push, pull_request]
+
+jobs:
+    test:
+
+        runs-on: ubuntu-latest
+
+        steps:
+        - uses: actions/checkout@v4
+        - name: Set up Python
+          uses: actions/setup-python@v3
+          with:
+            python-version: '3.x'
+        - name: Install dependencies
+          run: |
+            python -m pip install --upgrade pip
+            pip install .
+            pip install pytest
+        - name: Test with pytest
+          run: |
+            pytest


### PR DESCRIPTION
The previous dependency conflict patched in #138 could've been caught if there was a github action to automate this repo's unit tests, so I went and added one similar to the [github action in py-fsrs](https://github.com/open-spaced-repetition/py-fsrs/blob/main/.github/workflows/test.yml).

Let me know if this looks okay or if there are any questions 