### PR TITLE
Feat/support to set device for batch dataset

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "FSRS-Optimizer"
-version = "5.2.3"
+version = "5.3.0"
 readme = "README.md"
 dependencies = [
     "matplotlib>=3.7.0",

--- a/src/fsrs_optimizer/fsrs_optimizer.py
+++ b/src/fsrs_optimizer/fsrs_optimizer.py
@@ -219,6 +219,7 @@ class BatchDataset(Dataset):
         batch_size: int = 0,
         sort_by_length: bool = True,
         max_seq_len: int = math.inf,
+        device: str = "cpu",
     ):
         if dataframe.empty:
             raise ValueError("Training data is inadequate.")
@@ -248,10 +249,10 @@ class BatchDataset(Dataset):
                 max_seq_len = max(seq_lens)
                 sequences_truncated = sequences[:, :max_seq_len]
                 self.batches[i] = (
-                    sequences_truncated.transpose(0, 1),
-                    self.t_train[start_index:end_index],
-                    self.y_train[start_index:end_index],
-                    seq_lens,
+                    sequences_truncated.transpose(0, 1).to(device),
+                    self.t_train[start_index:end_index].to(device),
+                    self.y_train[start_index:end_index].to(device),
+                    seq_lens.to(device),
                 )
 
     def __getitem__(self, idx):


### PR DESCRIPTION
## Changes

Added device support to the BatchDataset class to allow tensor operations on specified devices (CPU/GPU).

## Technical Details

- Added new device parameter to BatchDataset constructor (defaults to "cpu")
- Moved batch tensors to the specified device, including:
  - Sequence data (sequences_truncated)
  - Interval data (t_train)
  - Label data (y_train)
  - Sequence length data (seq_lens)