### PR TITLE
Feat/option enable_short_term in training

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "FSRS-Optimizer"
-version = "5.4.2"
+version = "5.5.0"
 readme = "README.md"
 dependencies = [
     "matplotlib>=3.7.0",


### PR DESCRIPTION
same to https://github.com/open-spaced-repetition/fsrs-rs/pull/258

benchmark results:

Weighted by number of reviews

| Model | #Params | LogLoss | RMSE(bins) | AUC |
| --- | --- | --- | --- | --- |
| FSRS-5 | 19 | 0.328±0.0081 | 0.052±0.0015 | 0.701±0.0044 |
| FSRS-5-disable_short_term | 17 | 0.331±0.0082 | 0.053±0.0016 | 0.694±0.0042 |
| FSRS-4.5 | 17 | 0.332±0.0082 | 0.054±0.0016 | 0.692±0.0041 |

Weighted by number of users

| Model | #Params | LogLoss | RMSE(bins) | AUC |
| --- | --- | --- | --- | --- |
| FSRS-5 | 19 | 0.357±0.0045 | 0.074±0.0012 | 0.699±0.0024 |
| FSRS-5-disable_short_term | 17 | 0.361±0.0045 | 0.076±0.0013 | 0.690±0.0023 |
| FSRS-4.5 | 17 | 0.362±0.0045 | 0.076±0.0013 | 0.689±0.0023 |