### PR TITLE
Explicitly state compatible python versions in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "statsmodels>=0.13.5",
     "scipy<1.14.1"
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.9,<3.13"
 
 [project.urls]
 Homepage = "https://github.com/open-spaced-repetition/fsrs-optimizer"


### PR DESCRIPTION
The `FSRS-Optimizer` package relies on pytorch which is currently incompatible with python3.13.

If you run `pip install FSRS-Optimizer` with python3.13, you'll get a dependency conflict error and won't be able to install the package.

Given this, I modified the pyproject.toml to explicitly state which versions of python are currently compatible with this package.

Let me know if there are any questions/etc 👍