### PR TITLE
Expt/normalized cross entropy loss

### DIFF
--- a/src/fsrs_optimizer/fsrs_optimizer.py
+++ b/src/fsrs_optimizer/fsrs_optimizer.py
@@ -390,7 +390,7 @@ class Trainer:
                 outputs, _ = self.model(sequences)
                 stabilities = outputs[seq_lens - 1, torch.arange(real_batch_size), 0]
                 retentions = power_forgetting_curve(delta_ts, stabilities)
-                average_retention = retentions.mean().repeat(real_batch_size)
+                average_retention = labels.mean().repeat(real_batch_size)
                 normalized_cross_entropy = average_retention * torch.log(retentions) + (
                     1 - average_retention
                 ) * torch.log(1 - retentions)
@@ -453,7 +453,7 @@ class Trainer:
                 outputs, _ = self.model(sequences.transpose(0, 1))
                 stabilities = outputs[seq_lens - 1, torch.arange(real_batch_size), 0]
                 retentions = power_forgetting_curve(delta_ts, stabilities)
-                average_retention = retentions.mean().repeat(real_batch_size)
+                average_retention = labels.mean().repeat(real_batch_size)
                 normalized_cross_entropy = average_retention * torch.log(retentions) + (
                     1 - average_retention
                 ) * torch.log(1 - retentions)

--- a/src/fsrs_optimizer/fsrs_optimizer.py
+++ b/src/fsrs_optimizer/fsrs_optimizer.py
@@ -390,12 +390,10 @@ class Trainer:
                 outputs, _ = self.model(sequences)
                 stabilities = outputs[seq_lens - 1, torch.arange(real_batch_size), 0]
                 retentions = power_forgetting_curve(delta_ts, stabilities)
-                normalized_retentions = torch.full_like(
-                    labels, labels.mean().clamp(0.0001, 0.9999)
-                )
-                normalized_cross_entropy = normalized_retentions * torch.log(
-                    retentions
-                ) + (1 - normalized_retentions) * torch.log(1 - retentions)
+                average_retention = retentions.mean().repeat(real_batch_size)
+                normalized_cross_entropy = average_retention * torch.log(retentions) + (
+                    1 - average_retention
+                ) * torch.log(1 - retentions)
                 loss = (
                     self.loss_fn(retentions, labels)
                     * weights
@@ -455,12 +453,10 @@ class Trainer:
                 outputs, _ = self.model(sequences.transpose(0, 1))
                 stabilities = outputs[seq_lens - 1, torch.arange(real_batch_size), 0]
                 retentions = power_forgetting_curve(delta_ts, stabilities)
-                normalized_retentions = torch.full_like(
-                    labels, labels.mean().clamp(0.0001, 0.9999)
-                )
-                normalized_cross_entropy = normalized_retentions * torch.log(
-                    retentions
-                ) + (1 - normalized_retentions) * torch.log(1 - retentions)
+                average_retention = retentions.mean().repeat(real_batch_size)
+                normalized_cross_entropy = average_retention * torch.log(retentions) + (
+                    1 - average_retention
+                ) * torch.log(1 - retentions)
                 loss = (
                     self.loss_fn(retentions, labels)
                     * weights

--- a/src/fsrs_optimizer/fsrs_optimizer.py
+++ b/src/fsrs_optimizer/fsrs_optimizer.py
@@ -390,10 +390,12 @@ class Trainer:
                 outputs, _ = self.model(sequences)
                 stabilities = outputs[seq_lens - 1, torch.arange(real_batch_size), 0]
                 retentions = power_forgetting_curve(delta_ts, stabilities)
-                average_retention = labels.mean().repeat(real_batch_size)
-                normalized_cross_entropy = average_retention * torch.log(average_retention) + (
-                    1 - average_retention
-                ) * torch.log(1 - average_retention)
+                average_retention = (
+                    labels.mean().clamp(0.0001, 0.9999).repeat(real_batch_size)
+                )
+                normalized_cross_entropy = average_retention * torch.log(
+                    average_retention
+                ) + (1 - average_retention) * torch.log(1 - average_retention)
                 loss = (
                     self.loss_fn(retentions, labels)
                     * weights
@@ -453,10 +455,12 @@ class Trainer:
                 outputs, _ = self.model(sequences.transpose(0, 1))
                 stabilities = outputs[seq_lens - 1, torch.arange(real_batch_size), 0]
                 retentions = power_forgetting_curve(delta_ts, stabilities)
-                average_retention = labels.mean().repeat(real_batch_size)
-                normalized_cross_entropy = average_retention * torch.log(average_retention) + (
-                    1 - average_retention
-                ) * torch.log(1 - average_retention)
+                average_retention = (
+                    labels.mean().clamp(0.0001, 0.9999).repeat(real_batch_size)
+                )
+                normalized_cross_entropy = average_retention * torch.log(
+                    average_retention
+                ) + (1 - average_retention) * torch.log(1 - average_retention)
                 loss = (
                     self.loss_fn(retentions, labels)
                     * weights

--- a/src/fsrs_optimizer/fsrs_optimizer.py
+++ b/src/fsrs_optimizer/fsrs_optimizer.py
@@ -390,7 +390,12 @@ class Trainer:
                 outputs, _ = self.model(sequences)
                 stabilities = outputs[seq_lens - 1, torch.arange(real_batch_size), 0]
                 retentions = power_forgetting_curve(delta_ts, stabilities)
-                loss = (self.loss_fn(retentions, labels) * weights).sum()
+                normalized_retentions = torch.full_like(
+                    labels, labels.mean().clamp(0.0001, 0.9999)
+                )
+                loss = (
+                    self.loss_fn(retentions, labels) * weights
+                ).sum() / self.loss_fn(normalized_retentions, labels).mean()
                 penalty = torch.sum(
                     torch.square(self.model.w - self.init_w_tensor)
                     / torch.square(DEFAULT_PARAMS_STDDEV_TENSOR)
@@ -445,7 +450,12 @@ class Trainer:
                 outputs, _ = self.model(sequences.transpose(0, 1))
                 stabilities = outputs[seq_lens - 1, torch.arange(real_batch_size), 0]
                 retentions = power_forgetting_curve(delta_ts, stabilities)
-                loss = (self.loss_fn(retentions, labels) * weights).mean()
+                normalized_retentions = torch.full_like(
+                    labels, labels.mean().clamp(0.0001, 0.9999)
+                )
+                loss = (
+                    self.loss_fn(retentions, labels) * weights
+                ).sum() / self.loss_fn(normalized_retentions, labels).mean()
                 penalty = torch.sum(
                     torch.square(self.model.w - self.init_w_tensor)
                     / torch.square(DEFAULT_PARAMS_STDDEV_TENSOR)

--- a/src/fsrs_optimizer/fsrs_optimizer.py
+++ b/src/fsrs_optimizer/fsrs_optimizer.py
@@ -391,9 +391,9 @@ class Trainer:
                 stabilities = outputs[seq_lens - 1, torch.arange(real_batch_size), 0]
                 retentions = power_forgetting_curve(delta_ts, stabilities)
                 average_retention = labels.mean().repeat(real_batch_size)
-                normalized_cross_entropy = average_retention * torch.log(retentions) + (
+                normalized_cross_entropy = average_retention * torch.log(average_retention) + (
                     1 - average_retention
-                ) * torch.log(1 - retentions)
+                ) * torch.log(1 - average_retention)
                 loss = (
                     self.loss_fn(retentions, labels)
                     * weights
@@ -454,9 +454,9 @@ class Trainer:
                 stabilities = outputs[seq_lens - 1, torch.arange(real_batch_size), 0]
                 retentions = power_forgetting_curve(delta_ts, stabilities)
                 average_retention = labels.mean().repeat(real_batch_size)
-                normalized_cross_entropy = average_retention * torch.log(retentions) + (
+                normalized_cross_entropy = average_retention * torch.log(average_retention) + (
                     1 - average_retention
-                ) * torch.log(1 - retentions)
+                ) * torch.log(1 - average_retention)
                 loss = (
                     self.loss_fn(retentions, labels)
                     * weights

--- a/src/fsrs_optimizer/fsrs_optimizer.py
+++ b/src/fsrs_optimizer/fsrs_optimizer.py
@@ -393,9 +393,14 @@ class Trainer:
                 normalized_retentions = torch.full_like(
                     labels, labels.mean().clamp(0.0001, 0.9999)
                 )
+                normalized_cross_entropy = normalized_retentions * torch.log(
+                    retentions
+                ) + (1 - normalized_retentions) * torch.log(1 - retentions)
                 loss = (
-                    self.loss_fn(retentions, labels) * weights
-                ).sum() / self.loss_fn(normalized_retentions, labels).mean()
+                    self.loss_fn(retentions, labels)
+                    * weights
+                    / normalized_cross_entropy
+                ).sum()
                 penalty = torch.sum(
                     torch.square(self.model.w - self.init_w_tensor)
                     / torch.square(DEFAULT_PARAMS_STDDEV_TENSOR)
@@ -453,9 +458,14 @@ class Trainer:
                 normalized_retentions = torch.full_like(
                     labels, labels.mean().clamp(0.0001, 0.9999)
                 )
+                normalized_cross_entropy = normalized_retentions * torch.log(
+                    retentions
+                ) + (1 - normalized_retentions) * torch.log(1 - retentions)
                 loss = (
-                    self.loss_fn(retentions, labels) * weights
-                ).sum() / self.loss_fn(normalized_retentions, labels).mean()
+                    self.loss_fn(retentions, labels)
+                    * weights
+                    / normalized_cross_entropy
+                ).sum()
                 penalty = torch.sum(
                     torch.square(self.model.w - self.init_w_tensor)
                     / torch.square(DEFAULT_PARAMS_STDDEV_TENSOR)


### PR DESCRIPTION
@Expertium, is it what you want?

Here is my preliminary benchmark result:

```
Model: FSRS-5-dev
Total number of users: 1990
Total number of reviews: 66177965
Weighted average by reviews:
FSRS-5-dev LogLoss (mean±std): 0.3437±0.1561
FSRS-5-dev RMSE(bins) (mean±std): 0.0556±0.0337
FSRS-5-dev AUC (mean±std): 0.6982±0.0841

Weighted average by log(reviews):
FSRS-5-dev LogLoss (mean±std): 0.3608±0.1687
FSRS-5-dev RMSE(bins) (mean±std): 0.0715±0.0446
FSRS-5-dev AUC (mean±std): 0.6960±0.0926

Weighted average by users:
FSRS-5-dev LogLoss (mean±std): 0.3630±0.1710
FSRS-5-dev RMSE(bins) (mean±std): 0.0739±0.0460
FSRS-5-dev AUC (mean±std): 0.6955±0.0946

parameters: [0.4286, 1.33325, 3.135, 15.55505, 7.1809, 0.55095, 1.74625, 0.00605, 1.5458, 0.1192, 1.0193, 1.92735, 0.1056, 0.2961, 2.30255, 0.2315, 2.9898, 0.4842, 0.6621]

Model: FSRS-5
Total number of users: 1990
Total number of reviews: 66177965
Weighted average by reviews:
FSRS-5 LogLoss (mean±std): 0.3415±0.1558
FSRS-5 RMSE(bins) (mean±std): 0.0546±0.0334
FSRS-5 AUC (mean±std): 0.7047±0.0813

Weighted average by log(reviews):
FSRS-5 LogLoss (mean±std): 0.3590±0.1681
FSRS-5 RMSE(bins) (mean±std): 0.0712±0.0445
FSRS-5 AUC (mean±std): 0.7011±0.0878

Weighted average by users:
FSRS-5 LogLoss (mean±std): 0.3614±0.1704
FSRS-5 RMSE(bins) (mean±std): 0.0737±0.0459
FSRS-5 AUC (mean±std): 0.7005±0.0898

parameters: [0.4208, 1.1358, 3.00825, 15.49955, 7.1794, 0.54405, 1.7145, 0.00635, 1.51585, 0.1256, 1.00245, 1.9359, 0.1069, 0.2932, 2.27565, 0.23055, 2.9898, 0.4591, 0.63255]
```