### PR TITLE
Expt/Hard Abuse Detection

### DIFF
--- a/src/fsrs_optimizer/fsrs_optimizer.py
+++ b/src/fsrs_optimizer/fsrs_optimizer.py
@@ -117,7 +117,7 @@ class FSRS(nn.Module):
 
     def stability_after_failure(self, state: Tensor, r: Tensor, rating: Tensor) -> Tensor:
         old_s = state[:, 0]
-        hard_bonus = torch.where(rating == 2, -self.w[15], rating)
+        hard_bonus = torch.where(rating == 2, 1 - self.w[15], rating)
         new_s = (
             self.w[11]
             * torch.pow(state[:, 1], -self.w[12])

--- a/src/fsrs_optimizer/fsrs_optimizer.py
+++ b/src/fsrs_optimizer/fsrs_optimizer.py
@@ -117,7 +117,7 @@ class FSRS(nn.Module):
 
     def stability_after_failure(self, state: Tensor, r: Tensor, rating: Tensor) -> Tensor:
         old_s = state[:, 0]
-        hard_bonus = torch.where(rating == 2, torch.exp(2 + self.w[15]), 1)
+        hard_bonus = torch.where(rating == 2, 4 + (self.w[15] * 4), 1)
         new_s = (
             self.w[11]
             * torch.pow(state[:, 1], -self.w[12])

--- a/src/fsrs_optimizer/fsrs_optimizer.py
+++ b/src/fsrs_optimizer/fsrs_optimizer.py
@@ -117,12 +117,12 @@ class FSRS(nn.Module):
 
     def stability_after_failure(self, state: Tensor, r: Tensor, rating: Tensor) -> Tensor:
         old_s = state[:, 0]
-        hard_bonus = torch.where(rating == 2, 2 + self.w[15], rating)
+        hard_bonus = torch.where(rating == 2, torch.exp(2 + self.w[15]), 1)
         new_s = (
             self.w[11]
             * torch.pow(state[:, 1], -self.w[12])
             * (torch.pow(old_s + 1, self.w[13]) - 1)
-            * torch.exp((1 - r) * self.w[14])
+            * torch.exp((1 - (r * 1)) * self.w[14])
             * hard_bonus
         )
         new_minimum_s = old_s / torch.exp(self.w[17] * self.w[18])

--- a/src/fsrs_optimizer/fsrs_optimizer.py
+++ b/src/fsrs_optimizer/fsrs_optimizer.py
@@ -122,7 +122,7 @@ class FSRS(nn.Module):
             self.w[11]
             * torch.pow(state[:, 1], -self.w[12])
             * (torch.pow(old_s + 1, self.w[13]) - 1)
-            * torch.exp((1 - (r * 1)) * self.w[14])
+            * torch.exp((1 - r) * self.w[14])
             * hard_bonus
         )
         new_minimum_s = old_s / torch.exp(self.w[17] * self.w[18])

--- a/src/fsrs_optimizer/fsrs_optimizer.py
+++ b/src/fsrs_optimizer/fsrs_optimizer.py
@@ -117,13 +117,12 @@ class FSRS(nn.Module):
 
     def stability_after_failure(self, state: Tensor, r: Tensor, rating: Tensor) -> Tensor:
         old_s = state[:, 0]
-        hard_bonus = torch.where(rating == 2, 2 + self.w[15], rating)
+        hard_bonus = torch.where(rating == 2, 1.2 - self.w[15], rating)
         new_s = (
             self.w[11]
             * torch.pow(state[:, 1], -self.w[12])
-            * (torch.pow(old_s + 1, self.w[13]) - 1)
+            * (torch.pow(old_s + 1 * hard_bonus , self.w[13]) - 1)
             * torch.exp((1 - r) * self.w[14])
-            * hard_bonus
         )
         new_minimum_s = old_s / torch.exp(self.w[17] * self.w[18])
         return torch.minimum(new_s, new_minimum_s)

--- a/src/fsrs_optimizer/fsrs_optimizer.py
+++ b/src/fsrs_optimizer/fsrs_optimizer.py
@@ -120,12 +120,13 @@ class FSRS(nn.Module):
     ) -> Tensor:
         old_s = state[:, 0]
         hard_bonus = torch.where(rating == 2, 3.5 + (self.w[15] * 2.5), 1)
-        new_s = (
+        new_s = torch.min(
             self.w[11]
             * torch.pow(state[:, 1], -self.w[12])
             * (torch.pow(old_s + 1, self.w[13]) - 1)
             * torch.exp((1 - r) * self.w[14])
-            * hard_bonus
+            * hard_bonus,
+            self.stability_after_success(state, r, torch.ones_like(r) * 3),
         )
         new_minimum_s = old_s / torch.exp(self.w[17] * self.w[18])
         return torch.minimum(new_s, new_minimum_s)

--- a/src/fsrs_optimizer/fsrs_optimizer.py
+++ b/src/fsrs_optimizer/fsrs_optimizer.py
@@ -117,7 +117,7 @@ class FSRS(nn.Module):
 
     def stability_after_failure(self, state: Tensor, r: Tensor, rating: Tensor) -> Tensor:
         old_s = state[:, 0]
-        hard_bonus = torch.where(rating == 2, 4 + (self.w[15] * 3), 1)
+        hard_bonus = torch.where(rating == 2, 3.5 + (self.w[15] * (2.5)), 1)
         new_s = (
             self.w[11]
             * torch.pow(state[:, 1], -self.w[12])

--- a/src/fsrs_optimizer/fsrs_optimizer.py
+++ b/src/fsrs_optimizer/fsrs_optimizer.py
@@ -117,7 +117,7 @@ class FSRS(nn.Module):
 
     def stability_after_failure(self, state: Tensor, r: Tensor, rating: Tensor) -> Tensor:
         old_s = state[:, 0]
-        hard_bonus = torch.where(rating == 4, -self.w[15], rating)
+        hard_bonus = torch.where(rating == 2, -self.w[15], rating)
         new_s = (
             self.w[11]
             * torch.pow(state[:, 1], -self.w[12])

--- a/src/fsrs_optimizer/fsrs_optimizer.py
+++ b/src/fsrs_optimizer/fsrs_optimizer.py
@@ -117,7 +117,7 @@ class FSRS(nn.Module):
 
     def stability_after_failure(self, state: Tensor, r: Tensor, rating: Tensor) -> Tensor:
         old_s = state[:, 0]
-        hard_bonus = torch.where(rating == 2, 1 - self.w[15], rating)
+        hard_bonus = torch.where(rating == 2, 2 + self.w[15], rating)
         new_s = (
             self.w[11]
             * torch.pow(state[:, 1], -self.w[12])

--- a/src/fsrs_optimizer/fsrs_optimizer.py
+++ b/src/fsrs_optimizer/fsrs_optimizer.py
@@ -117,12 +117,13 @@ class FSRS(nn.Module):
 
     def stability_after_failure(self, state: Tensor, r: Tensor, rating: Tensor) -> Tensor:
         old_s = state[:, 0]
-        hard_bonus = torch.where(rating == 2, 1.2 - self.w[15], rating)
+        hard_bonus = torch.where(rating == 2, 2 + self.w[15], rating)
         new_s = (
             self.w[11]
             * torch.pow(state[:, 1], -self.w[12])
-            * (torch.pow(old_s + 1 * hard_bonus , self.w[13]) - 1)
+            * (torch.pow(old_s + 1, self.w[13]) - 1)
             * torch.exp((1 - r) * self.w[14])
+            * hard_bonus
         )
         new_minimum_s = old_s / torch.exp(self.w[17] * self.w[18])
         return torch.minimum(new_s, new_minimum_s)

--- a/src/fsrs_optimizer/fsrs_optimizer.py
+++ b/src/fsrs_optimizer/fsrs_optimizer.py
@@ -226,7 +226,7 @@ class ParameterClipper:
             w[12] = w[12].clamp(0.001, 0.25)
             w[13] = w[13].clamp(0.001, 0.9)
             w[14] = w[14].clamp(0, 4)
-            w[15] = w[15].clamp(-1, 1)
+            w[15] = w[15].clamp(-0.9999, 0.9999)
             w[16] = w[16].clamp(1, 6)
             w[17] = w[17].clamp(0, 2)
             w[18] = w[18].clamp(0, 2)

--- a/src/fsrs_optimizer/fsrs_optimizer.py
+++ b/src/fsrs_optimizer/fsrs_optimizer.py
@@ -117,7 +117,7 @@ class FSRS(nn.Module):
 
     def stability_after_failure(self, state: Tensor, r: Tensor, rating: Tensor) -> Tensor:
         old_s = state[:, 0]
-        hard_bonus = torch.where(rating == 2, 4 + (self.w[15] * 4), 1)
+        hard_bonus = torch.where(rating == 2, 4 + (self.w[15] * 3), 1)
         new_s = (
             self.w[11]
             * torch.pow(state[:, 1], -self.w[12])

--- a/src/fsrs_optimizer/fsrs_optimizer.py
+++ b/src/fsrs_optimizer/fsrs_optimizer.py
@@ -115,9 +115,11 @@ class FSRS(nn.Module):
         )
         return new_s
 
-    def stability_after_failure(self, state: Tensor, r: Tensor, rating: Tensor) -> Tensor:
+    def stability_after_failure(
+        self, state: Tensor, r: Tensor, rating: Tensor
+    ) -> Tensor:
         old_s = state[:, 0]
-        hard_bonus = torch.where(rating == 2, 3.5 + (self.w[15] * (2.5)), 1)
+        hard_bonus = torch.where(rating == 2, 3.5 + (self.w[15] * 2.5), 1)
         new_s = (
             self.w[11]
             * torch.pow(state[:, 1], -self.w[12])


### PR DESCRIPTION
The idea goes as follows (correct me if I'm wrong):

1. w[15] is a measure of the degree to which hard differs from good.
3. If the user is abusing hard, handling hard reviews with `stability_after_failure` should decrease the log loss.
4. Allow w[15] to go negative and use the negative w[15] as a "hard bonus" for `stability_after_failure`.

```py
success = X[:, 1] > (2 - self.w[15])
```
```py
        hard_bonus = torch.where(rating == 2, 3.5 + (self.w[15] * 2.5), 1)
```
(I eyeballed the 3.5, w[15] will be negative so its on a scale of 3.5 - 1 )

Using this script in the srs benchmark: https://gist.github.com/Luc-Mcgrady/89648eb2cdd7233b1267553284c7a22d
I get this result: https://pastebin.com/QnGaWpWv
(noticeably a small log loss improvement overall???!)
(My computers results vary from the regular results for some reason. I ran it both normally and with this change to compare but I still can't trust the results.)
```
---- Abusers: len(values)=63 mean(values)=0.0036330158730158726 sum(values)=0.22887999999999997 ----
```
With users like
```
user=98 w15:-0.9895, before=0.252682, after=0.230099, before-after=0.02258300000000002
user=686 w15:-0.9999, before=0.568046, after=0.536963, before-after=0.03108300000000008
```
Who seem to absolutely be hard abusers provided this method isn't flawed.

Edit: I made a mistake where hards failure stability could be above goods stability, should be fixed now but the values are out of date.