### PR TITLE
Fix/clamp the minimum of w[19]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "FSRS-Optimizer"
-version = "6.1.3"
+version = "6.1.4"
 readme = "README.md"
 dependencies = [
     "matplotlib>=3.7.0",

--- a/src/fsrs_optimizer/fsrs_optimizer.py
+++ b/src/fsrs_optimizer/fsrs_optimizer.py
@@ -233,7 +233,7 @@ class ParameterClipper:
             w[16] = w[16].clamp(1, 6)
             w[17] = w[17].clamp(0, 2)
             w[18] = w[18].clamp(0, 2)
-            w[19] = w[19].clamp(0, 0.8)
+            w[19] = w[19].clamp(0.01, 0.8)
             w[20] = w[20].clamp(0.1, 0.8)
             module.w.data = w
 


### PR DESCRIPTION
source: https://forums.ankiweb.net/t/endless-learning-phase/64821/3?u=l.m.sherlock

The regression of metrics is minor:

```
Model: FSRS-6-recency-dev
Total number of users: 9999
Total number of reviews: 349923850
Weighted average by reviews:
FSRS-6-recency-dev LogLoss (mean±std): 0.3197±0.1475
FSRS-6-recency-dev RMSE(bins) (mean±std): 0.0436±0.0275
FSRS-6-recency-dev AUC (mean±std): 0.7088±0.0767

Weighted average by log(reviews):
FSRS-6-recency-dev LogLoss (mean±std): 0.3412±0.1611
FSRS-6-recency-dev RMSE(bins) (mean±std): 0.0603±0.0387
FSRS-6-recency-dev AUC (mean±std): 0.7084±0.0852

Weighted average by users:
FSRS-6-recency-dev LogLoss (mean±std): 0.3438±0.1631
FSRS-6-recency-dev RMSE(bins) (mean±std): 0.0629±0.0403
FSRS-6-recency-dev AUC (mean±std): 0.7075±0.0870

parameters: [0.2381, 1.118, 3.2107, 13.5842, 6.4243, 0.7029, 3.0666, 0.0183, 1.8094, 0.1711, 0.7764, 1.497, 0.056, 0.3197, 1.6801, 0.4502, 1.9229, 0.6631, 0.1224, 0.1068, 0.1756]

Model: FSRS-6-recency
Total number of users: 9999
Total number of reviews: 349923850
Weighted average by reviews:
FSRS-6-recency LogLoss (mean±std): 0.3197±0.1475
FSRS-6-recency RMSE(bins) (mean±std): 0.0435±0.0275
FSRS-6-recency AUC (mean±std): 0.7088±0.0766

Weighted average by log(reviews):
FSRS-6-recency LogLoss (mean±std): 0.3412±0.1611
FSRS-6-recency RMSE(bins) (mean±std): 0.0603±0.0388
FSRS-6-recency AUC (mean±std): 0.7084±0.0852

Weighted average by users:
FSRS-6-recency LogLoss (mean±std): 0.3439±0.1631
FSRS-6-recency RMSE(bins) (mean±std): 0.0629±0.0403
FSRS-6-recency AUC (mean±std): 0.7075±0.0870

parameters: [0.2385, 1.1183, 3.2103, 13.5798, 6.4245, 0.7032, 3.0673, 0.0183, 1.8099, 0.1715, 0.7763, 1.497, 0.0558, 0.3197, 1.6803, 0.4503, 1.923, 0.662, 0.1241, 0.1066, 0.1751]
```