### PR TITLE
Fix dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,18 +6,21 @@ jobs:
     test:
 
         runs-on: ubuntu-latest
+        strategy:
+          matrix:
+            python-version: ["3.10", "3.11", "3.12", "3.13"]
 
         steps:
         - uses: actions/checkout@v4
-        - name: Set up Python
-          uses: actions/setup-python@v3
-          with:
-            python-version: '3.12'
-    
-        - name: Install uv
+
+        - name: Install uv and Set up Python
           uses: astral-sh/setup-uv@v5
           with:
             enable-cache: true
+            python-version: ${{ matrix.python-version }}
+
+        - name: Display Python version
+          run: python -V
 
         - name: Install the project
           run: uv sync --all-extras --dev

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires      = ["setuptools>=61.0.0", "wheel"]
+requires      = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -7,15 +7,15 @@ name = "FSRS-Optimizer"
 version = "6.1.5"
 readme = "README.md"
 dependencies = [
-    "matplotlib>=3.7.0",
-    "numpy>=1.22.4",
-    "pandas>=1.5.3",
-    "pytz>=2022.7.1",
-    "scikit_learn>=1.4.0",
-    "torch>=1.13.1",
-    "tqdm>=4.64.1",
-    "statsmodels>=0.13.5",
-    "scipy<1.14.1"
+    "matplotlib",
+    "numpy",
+    "pandas",
+    "pytz",
+    "scikit_learn",
+    "torch",
+    "tqdm",
+    "statsmodels",
+    "scipy"
 ]
 requires-python = ">=3.9,<3.13"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "statsmodels",
     "scipy"
 ]
-requires-python = ">=3.9,<3.13"
+requires-python = ">=3.10,<3.14"
 
 [project.urls]
 Homepage = "https://github.com/open-spaced-repetition/fsrs-optimizer"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "FSRS-Optimizer"
-version = "6.1.5"
+version = "6.1.6"
 readme = "README.md"
 dependencies = [
     "matplotlib",


### PR DESCRIPTION
I was trying to install the dependencies for [srs-benchmark](https://github.com/open-spaced-repetition/srs-benchmark) using python 3.13 earlier today and was having some trouble. Specifically, I was having issues with this dependency.

To fix, I did the following:

1. Moved the supported python versions to 3.10-3.13. Before it was 3.9-3.12. Note that 3.9 will no longer be supported starting next week. And torch is currently not supported with 3.14.
2. I unpinned the dependencies so now it's up to the package manager to decide which versions of the dependencies to install. This will make it easier to include this package as a dependency. And if it causes problems downstream, we could always try to pin the version numbers again.

Additionally,

1. I modified the test gh workflow to run the tests in python versions 3.10-3.13 to make sure it all works
2. Bumped the patch number for release

Lmk if you have any questions!

And if this gets merged, could you do a release so that I can run the benchmark with python 3.13?